### PR TITLE
Fix sirupsen casing

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -9,7 +9,7 @@ import (
 	"strings"
 	"text/template"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/jonbodner/proteus/mapper"
 )
 

--- a/cmd/main.go
+++ b/cmd/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/jonbodner/dbtimer"
 	"github.com/jonbodner/proteus"
 	_ "github.com/lib/pq"

--- a/cmd/null/main.go
+++ b/cmd/null/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/jonbodner/proteus"
 	_ "github.com/lib/pq"
 	_ "github.com/mattn/go-sqlite3"

--- a/mapper/extract.go
+++ b/mapper/extract.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 
 	"database/sql/driver"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 )
 
 func ExtractType(curType reflect.Type, path []string) (reflect.Type, error) {

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -4,7 +4,7 @@ import (
 	"database/sql"
 	"errors"
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"reflect"
 	"strings"
 	"unsafe"

--- a/proteus.go
+++ b/proteus.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 
 	"fmt"
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"strings"
 )
 

--- a/runner.go
+++ b/runner.go
@@ -7,7 +7,7 @@ import (
 
 	"database/sql"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/jonbodner/proteus/mapper"
 )
 

--- a/speed/speed.go
+++ b/speed/speed.go
@@ -6,7 +6,7 @@ import (
 	"os"
 	"time"
 
-	log "github.com/Sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
 	"github.com/jonbodner/proteus"
 	_ "github.com/mutecomm/go-sqlcipher"
 	"github.com/pkg/profile"


### PR DESCRIPTION
Lower case is the standard. See https://github.com/sirupsen/logrus/issues/570#issuecomment-313933276

I ran `find . -type f -name '*.go' -exec sed -i '' 's/Sirupsen/sirupsen/g' {} +` to produce this.