### PR TITLE
Erase mentions of proe

### DIFF
--- a/example2_test.go
+++ b/example2_test.go
@@ -7,7 +7,7 @@ import (
 )
 
 type CreateProductDao struct {
-	Insert func(e Executor, id int, name string, cost float64) (int64, error) `proe:"insert into product(id, name, cost) values(:id:, :name:, :cost:)" prop:"id,name,cost"`
+	Insert func(e Executor, id int, name string, cost float64) (int64, error) `proq:"insert into product(id, name, cost) values(:id:, :name:, :cost:)" prop:"id,name,cost"`
 }
 
 func Example_create() {

--- a/example_test.go
+++ b/example_test.go
@@ -14,10 +14,10 @@ type Product struct {
 
 type ProductDao struct {
 	FindById             func(e Executor, id int) (Product, error)                                     `proq:"select * from Product where id = :id:" prop:"id"`
-	Update               func(e Executor, p Product) (int64, error)                                    `proe:"update Product set name = :p.Name:, cost = :p.Cost: where id = :p.Id:" prop:"p"`
+	Update               func(e Executor, p Product) (int64, error)                                    `proq:"update Product set name = :p.Name:, cost = :p.Cost: where id = :p.Id:" prop:"p"`
 	FindByNameAndCost    func(e Executor, name string, cost float64) ([]Product, error)                `proq:"select * from Product where name=:name: and cost=:cost:" prop:"name,cost"`
 	FindByIdMap          func(e Executor, id int) (map[string]interface{}, error)                      `proq:"select * from Product where id = :id:" prop:"id"`
-	UpdateMap            func(e Executor, p map[string]interface{}) (int64, error)                     `proe:"update Product set name = :p.Name:, cost = :p.Cost: where id = :p.Id:" prop:"p"`
+	UpdateMap            func(e Executor, p map[string]interface{}) (int64, error)                     `proq:"update Product set name = :p.Name:, cost = :p.Cost: where id = :p.Id:" prop:"p"`
 	FindByNameAndCostMap func(e Executor, name string, cost float64) ([]map[string]interface{}, error) `proq:"select * from Product where name=:name: and cost=:cost:" prop:"name,cost"`
 }
 

--- a/proteus.go
+++ b/proteus.go
@@ -11,8 +11,9 @@ import (
 
 /*
 struct tags:
-proq - Query run by Executor.Query. Returns single entity or list of entities
-proe - Query run by Executor.Exec. Returns new id (if sql.Result has a non-zero value for LastInsertId) or number of rows changed
+proq - SQL code to execute
+	If the first parameter is an Executor, returns new id (if sql.Result has a non-zero value for LastInsertId) or number of rows changed.
+	If the first parameter is a Querier, returns single entity or list of entities.
 prop - The parameter names. Should be in order for the function parameters (skipping over the first Executor parameter)
 prof - The fields on the dto that are mapped to select parameters in a query
 next:


### PR DESCRIPTION
Since `proe` no longer exists, remove it everywhere to avoid confusing users.