### PR TITLE
Make []byte a special case that doesn't expand into multiple values and stays a blob of binary data.

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -118,7 +118,8 @@ func buildFixedQueryAndParamOrder(c context.Context, query string, nameOrderMap 
 					}
 					out.WriteString(addSlice(id))
 					isSlice := false
-					if pathType != nil && pathType.Kind() == reflect.Slice && !pathType.Implements(valueType) {
+					//special case -- slice of bytes is never expanded out into a comma-separated list
+					if pathType != nil && pathType.Kind() == reflect.Slice && !pathType.Implements(valueType) && pathType.Elem().Kind() != reflect.Uint8 {
 						hasSlice = true
 						isSlice = true
 					}


### PR DESCRIPTION
This feels like the right behavior, but if someone has a case where a []byte should be expanded out, I can revisit this with a different approach.