### PR TITLE
Deleted leftover fmt.Println from debugging

### DIFF
--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -95,8 +95,6 @@ func buildColFieldMap(sType reflect.Type, parentFieldInfo fieldInfo, colFieldMap
 			// prepend the parent struct and store off a fieldi
 			// only if this doesn't implement a scanner. If it does, then go with the scanner
 			// another special case: time.Time isn't recursed into
-			fmt.Println(sf.Type.Name())
-			fmt.Println(sf.Type.PkgPath())
 			if sf.Type.Kind() == reflect.Struct && !reflect.PtrTo(sf.Type).Implements(scannerType) && sf.Type.Name() != "Time" && sf.Type.PkgPath() != "time"  {
 				buildColFieldMap(sf.Type, childFieldInfo, colFieldMap)
 			} else {


### PR DESCRIPTION
Thanks for the extremely quick fix to #27! The fix contained a few fmt.Println. Here's a fix deleting them.