### PR TITLE
trim parameters specified in the 'prop' tag for spaces to handle spac…

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -20,7 +20,7 @@ func buildNameOrderMap(paramOrder string) map[string]int {
 	out := map[string]int{}
 	params := strings.Split(paramOrder, ",")
 	for k, v := range params {
-		out[v] = k + 1
+		out[strings.TrimSpace(v)] = k + 1
 	}
 	return out
 }


### PR DESCRIPTION
…es after commas gracefully

fixes #31 