### PR TITLE
Add proteus.Builder and methods to generate individual functions and ad-hoc queries

### DIFF
--- a/builder.go
+++ b/builder.go
@@ -58,7 +58,11 @@ var (
 	valueType = reflect.TypeOf((*driver.Valuer)(nil)).Elem()
 )
 
-func buildFixedQueryAndParamOrder(c context.Context, query string, nameOrderMap map[string]int, funcType reflect.Type, pa ParamAdapter) (queryHolder, []paramInfo, error) {
+type posType interface {
+	In(i int) reflect.Type
+}
+
+func buildFixedQueryAndParamOrder(c context.Context, query string, nameOrderMap map[string]int, funcType posType, pa ParamAdapter) (queryHolder, []paramInfo, error) {
 	var out bytes.Buffer
 
 	var paramOrder []paramInfo

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/jonbodner/proteus
 go 1.12
 
 require (
+	github.com/google/go-cmp v0.3.0
 	github.com/jonbodner/dbtimer v0.0.0-20170410163237-7002f3758ae1
 	github.com/jonbodner/multierr v0.0.0-20181226035711-ce28e9ccaa7d
 	github.com/lib/pq v1.1.1

--- a/go.sum
+++ b/go.sum
@@ -1,6 +1,8 @@
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/google/go-cmp v0.3.0 h1:crn/baboCvb5fXaQ0IJ1SGTsTVrWpDsCWC8EGETZijY=
+github.com/google/go-cmp v0.3.0/go.mod h1:8QqcDgzrUqlUb/G2PQTWiueGozuR1884gddMywk6iLU=
 github.com/jonbodner/dbtimer v0.0.0-20170410163237-7002f3758ae1 h1:mgFL7UFb88FOlSVgVoIRGJ4yKlkfp8KcXHqy7no+lEU=
 github.com/jonbodner/dbtimer v0.0.0-20170410163237-7002f3758ae1/go.mod h1:PjOlFbeJKs+4b2CvuN9FFF8Ed8cZ6FHWPb5tLK2QKOM=
 github.com/jonbodner/multierr v0.0.0-20181226035711-ce28e9ccaa7d h1:Ypy41GdYadUvX45qz4ux8BExKtPuBpSEeDNcyHhiOEg=

--- a/mapper/mapper.go
+++ b/mapper/mapper.go
@@ -29,7 +29,7 @@ func ptrConverter(c context.Context, isPtr bool, sType reflect.Type, out reflect
 	}
 	k := out.Type().Kind()
 	if (k == reflect.Ptr || k == reflect.Interface) && out.IsNil() {
-		return nil, fmt.Errorf("Attempting to return nil for non-pointer type %v", sType)
+		return nil, fmt.Errorf("attempting to return nil for non-pointer type %v", sType)
 	}
 	return out.Interface(), nil
 }
@@ -52,7 +52,7 @@ func MakeBuilder(c context.Context, sType reflect.Type) (Builder, error) {
 
 	if sType.Kind() == reflect.Map {
 		if sType.Key().Kind() != reflect.String {
-			return nil, errors.New("Only maps with string keys are supported")
+			return nil, errors.New("only maps with string keys are supported")
 		}
 		return func(cols []string, vals []interface{}) (interface{}, error) {
 			out, err := buildMap(c, sType, cols, vals)
@@ -137,7 +137,7 @@ func buildMap(c context.Context, sType reflect.Type, cols []string, vals []inter
 		if rv.Elem().Elem().Type().ConvertibleTo(sType.Elem()) {
 			out.SetMapIndex(reflect.ValueOf(v), rv.Elem().Elem().Convert(sType.Elem()))
 		} else {
-			return out, fmt.Errorf("Unable to assign value %v of type %v to map value of type %v with key %s", rv.Elem().Elem(), rv.Elem().Elem().Type(), sType.Elem(), v)
+			return out, fmt.Errorf("unable to assign value %v of type %v to map value of type %v with key %s", rv.Elem().Elem(), rv.Elem().Elem().Type(), sType.Elem(), v)
 		}
 	}
 	return out, nil
@@ -185,7 +185,7 @@ func buildStructInner(c context.Context, sType reflect.Type, out reflect.Value, 
 			field.Elem().Set(rv.Elem().Elem().Convert(curFieldType.Elem()))
 		} else {
 			logger.Log(c, logger.ERROR, fmt.Sprintln("can't find the field"))
-			return fmt.Errorf("Unable to assign pointer to value %v of type %v to struct field %s of type %v", rv.Elem().Elem(), rv.Elem().Elem().Type(), sf.name[depth], curFieldType)
+			return fmt.Errorf("unable to assign pointer to value %v of type %v to struct field %s of type %v", rv.Elem().Elem(), rv.Elem().Elem().Type(), sf.name[depth], curFieldType)
 		}
 	} else {
 		if reflect.PtrTo(curFieldType).Implements(scannerType) {
@@ -202,12 +202,12 @@ func buildStructInner(c context.Context, sType reflect.Type, out reflect.Value, 
 			}
 		} else if rv.Elem().IsNil() {
 			logger.Log(c, logger.ERROR, fmt.Sprintln("Attempting to assign a nil to a non-pointer field"))
-			return fmt.Errorf("Unable to assign nil value to non-pointer struct field %s of type %v", sf.name[depth], curFieldType)
+			return fmt.Errorf("unable to assign nil value to non-pointer struct field %s of type %v", sf.name[depth], curFieldType)
 		} else if rv.Elem().Elem().Type().ConvertibleTo(curFieldType) {
 			field.Set(rv.Elem().Elem().Convert(curFieldType))
 		} else {
 			logger.Log(c, logger.ERROR, fmt.Sprintln("can't find the field"))
-			return fmt.Errorf("Unable to assign value %v of type %v to struct field %s of type %v", rv.Elem().Elem(), rv.Elem().Elem().Type(), sf.name[depth], curFieldType)
+			return fmt.Errorf("unable to assign value %v of type %v to struct field %s of type %v", rv.Elem().Elem(), rv.Elem().Elem().Type(), sf.name[depth], curFieldType)
 		}
 	}
 	return nil
@@ -223,7 +223,7 @@ func buildPrimitive(c context.Context, sType reflect.Type, cols []string, vals [
 	if rv.Elem().Elem().Type().ConvertibleTo(sType) {
 		out.Set(rv.Elem().Elem().Convert(sType))
 	} else {
-		return out, fmt.Errorf("Unable to assign value %v of type %v to return type of type %v", rv.Elem().Elem(), rv.Elem().Elem().Type(), sType)
+		return out, fmt.Errorf("unable to assign value %v of type %v to return type of type %v", rv.Elem().Elem(), rv.Elem().Elem().Type(), sType)
 	}
 	return out, nil
 }

--- a/mapper_test.go
+++ b/mapper_test.go
@@ -198,8 +198,8 @@ func TestBuildSqlitePrimitiveNilFail(t *testing.T) {
 	if err == nil {
 		t.Error("Expected error didn't get one")
 	}
-	if err.Error() != "Attempting to return nil for non-pointer type string" {
-		t.Errorf("Expected error message '%s', got '%s'", "Attempting to return nil for non-pointer type string", err.Error())
+	if err.Error() != "attempting to return nil for non-pointer type string" {
+		t.Errorf("Expected error message '%s', got '%s'", "attempting to return nil for non-pointer type string", err.Error())
 	}
 
 	s, err = mapRows(c, rows, b)

--- a/proteus_function.go
+++ b/proteus_function.go
@@ -1,0 +1,191 @@
+package proteus
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"reflect"
+	"strings"
+
+	"github.com/jonbodner/proteus/logger"
+	"github.com/jonbodner/proteus/mapper"
+)
+
+type Builder struct {
+	adapter ParamAdapter
+	mappers []QueryMapper
+}
+
+func NewBuilder(adapter ParamAdapter, mappers ...QueryMapper) Builder {
+	return Builder{
+		adapter: adapter,
+		mappers: mappers,
+	}
+}
+
+func (fb Builder) BuildFunction(c context.Context, f interface{}, query string, names []string) error {
+	//if log level is set and not in the context, use it
+	if _, ok := logger.LevelFromContext(c); !ok && l != logger.OFF {
+		rw.RLock()
+		c = logger.WithLevel(c, l)
+		rw.RUnlock()
+	}
+
+	// make sure that f is of the right type (pointer to function)
+	funcPointerType := reflect.TypeOf(f)
+	//must be a pointer to func
+	if funcPointerType.Kind() != reflect.Ptr {
+		return errors.New("not a pointer")
+	}
+	funcType := funcPointerType.Elem()
+	//if not a func, error out
+	if funcType.Kind() != reflect.Func {
+		return errors.New("not a pointer to func")
+	}
+
+	//validate to make sure that the function matches what we expect
+	hasCtx, err := validateFunction(funcType)
+	if err != nil {
+		return err
+	}
+
+	var nameOrderMap map[string]int
+	startPos := 1
+	if hasCtx {
+		startPos = 2
+	}
+	if len(names) == 0 {
+		nameOrderMap = buildDummyParameters(funcType.NumIn(), startPos)
+	} else {
+		nameOrderMap = buildFuncNameOrderMap(names, startPos)
+	}
+
+	//check to see if the query is in a QueryMapper
+	query, err = lookupQuery(query, fb.mappers)
+	if err != nil {
+		return err
+	}
+
+	implementation, err := makeImplementation(c, funcType, query, fb.adapter, nameOrderMap)
+	if err != nil {
+		return err
+	}
+
+	reflect.ValueOf(f).Elem().Set(reflect.MakeFunc(funcType, implementation))
+
+	return nil
+}
+
+func buildFuncNameOrderMap(names []string, startPos int) map[string]int {
+	out := map[string]int{}
+	for k, v := range names {
+		out[strings.TrimSpace(v)] = k + startPos
+	}
+	return out
+}
+
+type sliceTypes []reflect.Type
+
+func (st sliceTypes) In(i int) reflect.Type {
+	return st[i]
+}
+
+func (fb Builder) Execute(c context.Context, e ContextExecutor, query string, params []interface{}, names []string) (int64, error) {
+	finalQuery, queryArgs, err := fb.setupDynamicQueries(c, query, params, names)
+	if err != nil {
+		return 0, err
+	}
+
+	logger.Log(c, logger.DEBUG, fmt.Sprintln("calling", finalQuery, "with params", queryArgs))
+	result, err := e.ExecContext(c, finalQuery, queryArgs...)
+	if err != nil {
+		return 0, err
+	}
+	count, err := result.RowsAffected()
+	return count, err
+}
+
+func (fb Builder) Query(c context.Context, q ContextQuerier, query string, params []interface{}, names []string, output interface{}) error {
+	// make sure that output is a pointer to something
+	outputPointerType := reflect.TypeOf(output)
+	if outputPointerType.Kind() != reflect.Ptr {
+		return errors.New("not a pointer")
+	}
+
+	finalQuery, queryArgs, err := fb.setupDynamicQueries(c, query, params, names)
+	if err != nil {
+		return err
+	}
+
+	logger.Log(c, logger.DEBUG, fmt.Sprintln("calling", finalQuery, "with params", queryArgs))
+	rows, err := q.QueryContext(c, finalQuery, queryArgs...)
+	if err != nil {
+		return err
+	}
+
+	sType := outputPointerType.Elem()
+	qZero := reflect.Zero(sType)
+	builder, err := mapper.MakeBuilder(c, sType)
+	if err != nil {
+		return err
+	}
+
+	val, err := handleMapping(c, sType, rows, builder)
+	if err != nil {
+		return err
+	}
+	outputValue := reflect.ValueOf(output).Elem()
+	if val == nil {
+		outputValue.Set(qZero)
+		return nil
+	}
+	outputValue.Set(reflect.ValueOf(val).Convert(sType))
+
+	return nil
+}
+
+func (fb Builder) setupDynamicQueries(c context.Context, query string, params []interface{}, names []string) (string, []interface{}, error) {
+	//if log level is set and not in the context, use it
+	if _, ok := logger.LevelFromContext(c); !ok && l != logger.OFF {
+		rw.RLock()
+		c = logger.WithLevel(c, l)
+		rw.RUnlock()
+	}
+
+	var nameOrderMap map[string]int
+	if len(names) == 0 {
+		nameOrderMap = buildDummyParameters(len(params), 0)
+	} else {
+		nameOrderMap = buildFuncNameOrderMap(names, 0)
+	}
+
+	//check to see if the query is in a QueryMapper
+	query, err := lookupQuery(query, fb.mappers)
+	if err != nil {
+		return "", nil, err
+	}
+
+	st := make(sliceTypes, 0, len(params))
+	args := make([]reflect.Value, 0, len(params))
+	for _, v := range params {
+		st = append(st, reflect.TypeOf(v))
+		args = append(args, reflect.ValueOf(v))
+	}
+
+	fixedQuery, paramOrder, err := buildFixedQueryAndParamOrder(c, query, nameOrderMap, st, fb.adapter)
+	if err != nil {
+		return "", nil, err
+	}
+
+	finalQuery, err := fixedQuery.finalize(c, args)
+	if err != nil {
+		return "", nil, err
+	}
+
+	queryArgs, err := buildQueryArgs(c, args, paramOrder)
+
+	if err != nil {
+		return "", nil, err
+	}
+	return finalQuery, queryArgs, nil
+}

--- a/proteus_function_test.go
+++ b/proteus_function_test.go
@@ -4,10 +4,79 @@ import (
 	"context"
 	"fmt"
 	"testing"
+
+	"github.com/google/go-cmp/cmp"
+	"github.com/jonbodner/proteus/logger"
 )
 
+func TestBuilder_BuildFunctionErrors(t *testing.T) {
+	b := NewBuilder(Postgres)
+	db := setupDbPostgres()
+	defer db.Close()
+	ctx := context.Background()
+
+	var f func()
+	var f2 func(context.Context, ContextExecutor)
+
+	data := []struct {
+		name   string
+		f      interface{}
+		query  string
+		params []string
+		errMsg string
+	}{
+		{
+			name:   "not a pointer",
+			f:      func() {},
+			query:  "",
+			params: nil,
+			errMsg: "not a pointer",
+		},
+		{
+			name:   "not a func",
+			f:      &struct{}{},
+			query:  "",
+			params: nil,
+			errMsg: "not a pointer to func",
+		},
+		{
+			name:   "not a valid func",
+			f:      &f,
+			query:  "",
+			params: nil,
+			errMsg: "need to supply an Executor or Querier parameter",
+		},
+		{
+			name:   "not a valid query",
+			f:      &f2,
+			query:  "q:nope",
+			params: nil,
+			errMsg: "no query found for name nope",
+		},
+		{
+			name:   "not a valid params",
+			f:      &f2,
+			query:  "SELECT * FROM PERSON WHERE id = :id:",
+			params: nil,
+			errMsg: "query Parameter id cannot be found in the incoming parameters",
+		},
+	}
+	for _, v := range data {
+		t.Run(v.name, func(t *testing.T) {
+			err := b.BuildFunction(ctx, v.f, v.query, v.params)
+			var errMsg string
+			if err != nil {
+				errMsg = err.Error()
+			}
+			if errMsg != v.errMsg {
+				t.Errorf("Expected error `%s`, got `%s`", v.errMsg, errMsg)
+			}
+		})
+	}
+}
+
 func TestBuilder_BuildFunction(t *testing.T) {
-	b := NewBuilder(Postgres, nil)
+	b := NewBuilder(Postgres)
 	db := setupDbPostgres()
 	defer db.Close()
 	ctx := context.Background()
@@ -17,6 +86,25 @@ func TestBuilder_BuildFunction(t *testing.T) {
 	if err != nil {
 		t.Fatalf("build function failed: %v", err)
 	}
+	rows, err := f(ctx, db, "Fred", 20)
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	if rows != 1 {
+		t.Error("Expected 1 row modified, got ", rows)
+	}
+
+	err = b.BuildFunction(ctx, &f, "INSERT INTO PERSON(name, age) VALUES(:$1:, :$2:)", nil)
+	if err != nil {
+		t.Fatalf("build function failed: %v", err)
+	}
+	rows, err = f(ctx, db, "Fred", 20)
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	if rows != 1 {
+		t.Error("Expected 1 row modified, got ", rows)
+	}
 
 	var g func(c context.Context, q ContextQuerier, id int) (*Person, error)
 	err = b.BuildFunction(ctx, &g, "SELECT * FROM PERSON WHERE id = :id:", []string{"id"})
@@ -24,128 +112,355 @@ func TestBuilder_BuildFunction(t *testing.T) {
 		t.Fatalf("build function 2 failed: %v", err)
 	}
 
-	rows, err := f(ctx, db, "Fred", 20)
-	if err != nil {
-		t.Fatalf("create failed: %v", err)
-	}
-	fmt.Println(rows)
-
 	p, err := g(ctx, db, 1)
 	if err != nil {
 		t.Fatalf("get failed: %v", err)
 	}
-	fmt.Println(p)
+	if p == nil || *p != (Person{1, "Fred", 20}) {
+		t.Error("Unexpected output: ", p)
+	}
+
+	var lines []string
+	logger.Config(logger.LoggerFunc(func(vals ...interface{}) error {
+		lines = append(lines, fmt.Sprintln(vals))
+		return nil
+	}))
+	SetLogLevel(logger.DEBUG)
+	err = b.BuildFunction(ctx, &g, "SELECT * FROM PERSON WHERE id = :id:", []string{"id"})
+	if err != nil {
+		t.Fatalf("build function 2a failed: %v", err)
+	}
+	if len(lines) != 3 {
+		t.Errorf("Expected %d lines, got %d: %#v", 3, len(lines), lines)
+	}
+
 }
 
-func TestBuilder_ExecuteQuery(t *testing.T) {
-	b := NewBuilder(Postgres, nil)
+func TestBuilder_Execute(t *testing.T) {
+	b := NewBuilder(Postgres)
 	db := setupDbPostgres()
 	defer db.Close()
 	ctx := context.Background()
-	rows, err := b.Execute(ctx, db, "INSERT INTO PERSON(name, age) VALUES(:name:, :age:)", map[string]interface{}{"name": "Fred", "age": 20})
-	if err != nil {
-		t.Fatalf("create failed: %v", err)
-	}
-	fmt.Println(rows)
-	rows, err = b.Execute(ctx, db, "INSERT INTO PERSON(name, age) VALUES(:name:, :age:)", map[string]interface{}{"name": "Bob", "age": 50})
-	if err != nil {
-		t.Fatalf("create 2 failed: %v", err)
-	}
-	fmt.Println(rows)
-	rows, err = b.Execute(ctx, db, "INSERT INTO PERSON(name, age) VALUES(:name:, :age:)", map[string]interface{}{"name": "Julia", "age": 32})
-	if err != nil {
-		t.Fatalf("create 3 failed: %v", err)
-	}
-	fmt.Println(rows)
-	rows, err = b.Execute(ctx, db, "INSERT INTO PERSON(name, age) VALUES(:name:, :age:)", map[string]interface{}{"name": "Pat", "age": 37})
-	if err != nil {
-		t.Fatalf("create 4 failed: %v", err)
-	}
-	fmt.Println(rows)
 
-	var p Person
-	err = b.Query(ctx, db, "SELECT * FROM PERSON WHERE id = :id:", map[string]interface{}{"id": 1}, &p)
-	if err != nil {
-		t.Fatalf("get failed: %v", err)
-	}
-	fmt.Println(p)
+	var lines []string
+	logger.Config(logger.LoggerFunc(func(vals ...interface{}) error {
+		lines = append(lines, fmt.Sprintln(vals))
+		return nil
+	}))
 
-	var people []Person
-	err = b.Query(ctx, db, "SELECT * FROM PERSON", nil, &people)
-	if err != nil {
-		t.Fatalf("get all failed: %v", err)
+	data := []struct {
+		name      string
+		ctx       context.Context
+		logLevel  logger.Level
+		query     string
+		params    map[string]interface{}
+		rows      int64
+		errMsg    string
+		lineCount int
+	}{
+		{
+			name:   "insert",
+			query:  "INSERT INTO PERSON(name, age) VALUES(:name:, :age:)",
+			params: map[string]interface{}{"name": "Fred", "age": 20},
+			rows:   1,
+		},
+		{
+			name:   "insert struct",
+			query:  "INSERT INTO PERSON(name, age) VALUES(:p.Name:, :p.Age:)",
+			params: map[string]interface{}{"p": Person{Name: "Bob", Age: 50}},
+			rows:   1,
+		},
+		{
+			name:   "insert map",
+			query:  "INSERT INTO PERSON(name, age) VALUES(:p.name:, :p.age:)",
+			params: map[string]interface{}{"p": map[string]interface{}{"name": "Julia", "age": 32}},
+			rows:   1,
+		},
+		{
+			name:   "insert unnamed",
+			query:  "INSERT INTO PERSON(name, age) VALUES(:$1:, :$2:)",
+			params: map[string]interface{}{"$1": "Pat", "$2": 37},
+			rows:   1,
+		},
+		{
+			name:   "bad query",
+			query:  "INSERT INTO PERSON(name, age VALUES(:name:, :age:)",
+			params: map[string]interface{}{"name": "Fred", "age": 20},
+			rows:   0,
+			errMsg: "pq: syntax error at or near \"VALUES\"",
+		},
+		{
+			name:   "bad args",
+			query:  "INSERT INTO PERSON(name, age) VALUES(:name stuff:, :age:)",
+			params: map[string]interface{}{"name": "Fred", "age": 20},
+			rows:   0,
+			errMsg: ". missing between parts of an identifier: name stuff",
+		},
+		{
+			name:   "no such query",
+			query:  "q:nope",
+			params: map[string]interface{}{"id": 1},
+			rows:   0,
+			errMsg: "no query found for name nope",
+		},
+		{
+			name:      "logging context",
+			ctx:       logger.WithLevel(ctx, logger.DEBUG),
+			query:     "INSERT INTO PERSON(name, age) VALUES(:name:, :age:)",
+			params:    map[string]interface{}{"name": "Fred", "age": 20},
+			rows:      1,
+			lineCount: 7,
+		},
+		{
+			name:      "logging default",
+			logLevel:  logger.DEBUG,
+			query:     "INSERT INTO PERSON(name, age) VALUES(:name:, :age:)",
+			params:    map[string]interface{}{"name": "Fred", "age": 20},
+			rows:      1,
+			lineCount: 7,
+		},
 	}
-	fmt.Println(people)
-
-	err = b.Query(ctx, db, "SELECT * from PERSON WHERE name=:name: and age in (:ages:) and id = :id:", map[string]interface{}{"id": 1, "ages": []int{20, 32}, "name": "Fred"}, &people)
-	if err != nil {
-		t.Fatalf("get by age failed: %v", err)
+	for _, v := range data {
+		t.Run(v.name, func(t *testing.T) {
+			lines = nil
+			SetLogLevel(v.logLevel)
+			c := ctx
+			if v.ctx != nil {
+				c = v.ctx
+			}
+			rows, err := b.Exec(c, db, v.query, v.params)
+			var errMsg string
+			if err != nil {
+				errMsg = err.Error()
+			}
+			if errMsg != v.errMsg {
+				t.Errorf("Expected error `%s`, got `%s`", v.errMsg, errMsg)
+			}
+			if rows != v.rows {
+				t.Error("Unexpected # rows: ", rows)
+			}
+			if v.lineCount != len(lines) {
+				t.Errorf("Expected %d lines of debug, got %d: %#v", v.lineCount, len(lines), lines)
+			}
+		})
 	}
-	fmt.Println(people)
-
-	err = b.Query(ctx, db, "SELECT * from PERSON WHERE name=:$1: and age in (:$2:) and id = :$3:", map[string]interface{}{"$1": "Fred", "$2": []int{20, 32}, "$3": 1}, &people)
-	if err != nil {
-		t.Fatalf("get by age 2 failed: %v", err)
-	}
-	fmt.Println(people)
-
-	// or really non-typed
-	var p2 map[string]interface{}
-	err = b.Query(ctx, db, "SELECT * FROM PERSON WHERE id = :id:", map[string]interface{}{"id": 1}, &p2)
-	if err != nil {
-		t.Fatalf("get map failed: %v", err)
-	}
-	fmt.Println(p2)
-
-	var people2 []map[string]interface{}
-	err = b.Query(ctx, db, "SELECT * FROM PERSON where age > :$1: and age < :$2:", map[string]interface{}{"$1": 20, "$2": 50}, &people2)
-	if err != nil {
-		t.Fatalf("get map slice failed: %v", err)
-	}
-	fmt.Println(people2)
-
-	var p3 map[string]interface{}
-	err = b.Query(ctx, db, "SELECT * FROM PERSON WHERE id = :p.Id:", map[string]interface{}{"p": p}, &p3)
-	if err != nil {
-		t.Fatalf("get map 2 failed: %v", err)
-	}
-	fmt.Println(p3)
-
-	var p4 map[string]interface{}
-	err = b.Query(ctx, db, "SELECT * FROM PERSON WHERE id = :p.id:", map[string]interface{}{"p": p3}, &p4)
-	if err != nil {
-		t.Fatalf("get map 2 failed: %v", err)
-	}
-	fmt.Println(p4)
 }
 
-//func doPersonStuffForProteusTest(b *testing.B, wrapper Wrapper) (int64, *Person, []Person, error) {
-//
-//	count, err = personDao.Update(wrapper, 1, "Freddie", 30)
-//	if err != nil {
-//		b.Fatalf("update failed: %v", err)
-//	}
-//
-//	person, err = personDao.Get(wrapper, 1)
-//	if err != nil {
-//		b.Fatalf("get 2 failed: %v", err)
-//	}
-//
-//	count, err = personDao.Delete(wrapper, 1)
-//	if err != nil {
-//		b.Fatalf("delete failed: %v", err)
-//	}
-//
-//	count, err = personDao.Delete(wrapper, 1)
-//	if err != nil {
-//		b.Fatalf("delete 2 failed: %v", err)
-//	}
-//
-//	person, err = personDao.Get(wrapper, 1)
-//	if err != nil {
-//		b.Fatalf("get 3 failed: %v", err)
-//	}
-//
-//	return count, person, people, err
-//}
-//
+func TestBuilder_Query(t *testing.T) {
+	b := NewBuilder(Postgres)
+	db := setupDbPostgres()
+	defer db.Close()
+	ctx := context.Background()
+
+	// set up some data
+	_, err := b.Exec(ctx, db,
+		"INSERT INTO PERSON(name, age) VALUES(:name1:, :age1:),(:name2:, :age2:),(:name3:, :age3:),(:name4:, :age4:)",
+		map[string]interface{}{
+			"name1": "Fred", "age1": 20,
+			"name2": "Bob", "age2": 50,
+			"name3": "Julia", "age3": 32,
+			"name4": "Pat", "age4": 37,
+		})
+
+	if err != nil {
+		panic(err)
+	}
+
+	type BadPerson struct {
+		Id   int    `prof:"name"`
+		Name string `prof:"id"`
+		Age  string `prof:"age"`
+	}
+
+	var lines []string
+	logger.Config(logger.LoggerFunc(func(vals ...interface{}) error {
+		lines = append(lines, fmt.Sprintln(vals))
+		return nil
+	}))
+
+	data := []struct {
+		name      string
+		ctx       context.Context
+		logLevel  logger.Level
+		query     string
+		params    map[string]interface{}
+		out       interface{}
+		expected  interface{}
+		errMsg    string
+		lineCount int
+	}{
+		{
+			name:     "person by id",
+			query:    "SELECT * FROM PERSON WHERE id = :id:",
+			params:   map[string]interface{}{"id": 1},
+			out:      &Person{},
+			expected: &Person{Id: 1, Name: "Fred", Age: 20},
+		},
+		{
+			name:   "all people",
+			query:  "SELECT * FROM PERSON",
+			params: nil,
+			out:    &[]Person{},
+			expected: &[]Person{
+				{Id: 1, Name: "Fred", Age: 20},
+				{Id: 2, Name: "Bob", Age: 50},
+				{Id: 3, Name: "Julia", Age: 32},
+				{Id: 4, Name: "Pat", Age: 37},
+			},
+		},
+		{
+			name:   "all people in ages",
+			query:  "SELECT * from PERSON WHERE name=:name: and age in (:ages:) and id = :id:",
+			params: map[string]interface{}{"id": 1, "ages": []int{20, 32}, "name": "Fred"},
+			out:    &[]Person{},
+			expected: &[]Person{
+				{Id: 1, Name: "Fred", Age: 20},
+			},
+		},
+		{
+			name:   "all people in ages unnamed",
+			query:  "SELECT * from PERSON WHERE name=:$1: and age in (:$2:) and id = :$3:",
+			params: map[string]interface{}{"$1": "Fred", "$2": []int{20, 32}, "$3": 1},
+			out:    &[]Person{},
+			expected: &[]Person{
+				{Id: 1, Name: "Fred", Age: 20},
+			},
+		},
+		// or really non-typed
+		{
+			name:   "id untyped out",
+			query:  "SELECT * FROM PERSON WHERE id = :id:",
+			params: map[string]interface{}{"id": 1},
+			out:    &map[string]interface{}{},
+			expected: &map[string]interface{}{
+				"id": int64(1), "name": "Fred", "age": int64(20),
+			},
+		},
+		{
+			name:   "slice age untyped out",
+			query:  "SELECT * FROM PERSON where age > :$1: and age < :$2:",
+			params: map[string]interface{}{"$1": 20, "$2": 50},
+			out:    &[]map[string]interface{}{},
+			expected: &[]map[string]interface{}{
+				{"id": int64(3), "name": "Julia", "age": int64(32)},
+				{"id": int64(4), "name": "Pat", "age": int64(37)},
+			},
+		},
+		{
+			name:   "id from struct",
+			query:  "SELECT * FROM PERSON WHERE id = :p.Id:",
+			params: map[string]interface{}{"p": Person{Id: 1}},
+			out:    &map[string]interface{}{},
+			expected: &map[string]interface{}{
+				"id": int64(1), "name": "Fred", "age": int64(20),
+			},
+		},
+		{
+			name:   "id from map",
+			query:  "SELECT * FROM PERSON WHERE id = :p.id:",
+			params: map[string]interface{}{"p": map[string]interface{}{"id": 1}},
+			out:    &map[string]interface{}{},
+			expected: &map[string]interface{}{
+				"id": int64(1), "name": "Fred", "age": int64(20),
+			},
+		},
+		{
+			name:     "nothing returned",
+			query:    "SELECT * FROM PERSON WHERE id = :id:",
+			params:   map[string]interface{}{"id": 100},
+			out:      &Person{},
+			expected: &Person{},
+		},
+		{
+			name:      "nothing returned logging context",
+			ctx:       logger.WithLevel(ctx, logger.DEBUG),
+			query:     "SELECT * FROM PERSON WHERE id = :id:",
+			params:    map[string]interface{}{"id": 100},
+			out:       &Person{},
+			expected:  &Person{},
+			lineCount: 4,
+		},
+		{
+			name:      "nothing returned logging default",
+			logLevel:  logger.DEBUG,
+			query:     "SELECT * FROM PERSON WHERE id = :id:",
+			params:    map[string]interface{}{"id": 100},
+			out:       &Person{},
+			expected:  &Person{},
+			lineCount: 4,
+		},
+		// errors
+		{
+			name:     "not a pointer",
+			query:    "SELECT * FROM PERSON WHERE id = :id:",
+			params:   map[string]interface{}{"id": 1},
+			out:      Person{},
+			expected: Person{},
+			errMsg:   "not a pointer",
+		},
+		{
+			name:     "no such query",
+			query:    "q:nope",
+			params:   map[string]interface{}{"id": 1},
+			out:      &Person{},
+			expected: &Person{},
+			errMsg:   "no query found for name nope",
+		},
+		{
+			name:     "bad query",
+			query:    "SELECT * FROM PER SON WHERE id = :id:",
+			params:   map[string]interface{}{"id": 1},
+			out:      &Person{},
+			expected: &Person{},
+			errMsg:   `pq: relation "per" does not exist`,
+		},
+		{
+			name:     "bad target",
+			query:    "SELECT * FROM PERSON WHERE id = :id:",
+			params:   map[string]interface{}{"id": 1},
+			out:      &map[int]interface{}{},
+			expected: &map[int]interface{}{},
+			errMsg:   `only maps with string keys are supported`,
+		},
+		{
+			name:     "bad mapping",
+			query:    "SELECT * FROM PERSON WHERE id = :id:",
+			params:   map[string]interface{}{"id": 1},
+			out:      &BadPerson{},
+			expected: &BadPerson{},
+			errMsg:   "unable to assign value Fred of type string to struct field Id of type int",
+		},
+		{
+			name:     "bad in clause",
+			query:    "SELECT * FROM PERSON WHERE id in (:p.id:)",
+			params:   map[string]interface{}{"p": map[string]interface{}{"foo": "bar"}},
+			out:      &Person{},
+			expected: &Person{},
+			errMsg:   "cannot extract value; no such map key id",
+		},
+	}
+	for _, v := range data {
+		t.Run(v.name, func(t *testing.T) {
+			lines = nil
+			SetLogLevel(v.logLevel)
+			c := ctx
+			if v.ctx != nil {
+				c = v.ctx
+			}
+			err := b.Query(c, db, v.query, v.params, v.out)
+			var errMsg string
+			if err != nil {
+				errMsg = err.Error()
+			}
+			if errMsg != v.errMsg {
+				t.Errorf("Expected error `%s`, got `%s`", v.errMsg, errMsg)
+			}
+			if diff := cmp.Diff(v.out, v.expected); diff != "" {
+				t.Errorf(diff)
+			}
+			if v.lineCount != len(lines) {
+				t.Errorf("Expected %d lines of debug, got %d: %#v", v.lineCount, len(lines), lines)
+			}
+		})
+	}
+}

--- a/proteus_function_test.go
+++ b/proteus_function_test.go
@@ -42,52 +42,81 @@ func TestBuilder_ExecuteQuery(t *testing.T) {
 	db := setupDbPostgres()
 	defer db.Close()
 	ctx := context.Background()
-	rows, err := b.Execute(ctx, db, "INSERT INTO PERSON(name, age) VALUES(:name:, :age:)", []interface{}{"Fred", 20}, []string{"name", "age"})
+	rows, err := b.Execute(ctx, db, "INSERT INTO PERSON(name, age) VALUES(:name:, :age:)", map[string]interface{}{"name": "Fred", "age": 20})
 	if err != nil {
 		t.Fatalf("create failed: %v", err)
 	}
 	fmt.Println(rows)
-	rows, err = b.Execute(ctx, db, "INSERT INTO PERSON(name, age) VALUES(:name:, :age:)", []interface{}{"Bob", 50}, []string{"name", "age"})
+	rows, err = b.Execute(ctx, db, "INSERT INTO PERSON(name, age) VALUES(:name:, :age:)", map[string]interface{}{"name": "Bob", "age": 50})
 	if err != nil {
 		t.Fatalf("create 2 failed: %v", err)
 	}
 	fmt.Println(rows)
-	rows, err = b.Execute(ctx, db, "INSERT INTO PERSON(name, age) VALUES(:name:, :age:)", []interface{}{"Julia", 32}, []string{"name", "age"})
+	rows, err = b.Execute(ctx, db, "INSERT INTO PERSON(name, age) VALUES(:name:, :age:)", map[string]interface{}{"name": "Julia", "age": 32})
 	if err != nil {
 		t.Fatalf("create 3 failed: %v", err)
 	}
 	fmt.Println(rows)
-	rows, err = b.Execute(ctx, db, "INSERT INTO PERSON(name, age) VALUES(:name:, :age:)", []interface{}{"Pat", 37}, []string{"name", "age"})
+	rows, err = b.Execute(ctx, db, "INSERT INTO PERSON(name, age) VALUES(:name:, :age:)", map[string]interface{}{"name": "Pat", "age": 37})
 	if err != nil {
 		t.Fatalf("create 4 failed: %v", err)
 	}
 	fmt.Println(rows)
 
 	var p Person
-	err = b.Query(ctx, db, "SELECT * FROM PERSON WHERE id = :id:", []interface{}{1}, []string{"id"}, &p)
+	err = b.Query(ctx, db, "SELECT * FROM PERSON WHERE id = :id:", map[string]interface{}{"id": 1}, &p)
 	if err != nil {
 		t.Fatalf("get failed: %v", err)
 	}
 	fmt.Println(p)
 
 	var people []Person
-	err = b.Query(ctx, db, "SELECT * FROM PERSON", nil, nil, &people)
+	err = b.Query(ctx, db, "SELECT * FROM PERSON", nil, &people)
 	if err != nil {
 		t.Fatalf("get all failed: %v", err)
 	}
 	fmt.Println(people)
 
-	err = b.Query(ctx, db, "SELECT * from PERSON WHERE name=:name: and age in (:ages:) and id = :id:", []interface{}{1, []int{20, 32}, "Fred"}, []string{"id", "ages", "name"}, &people)
+	err = b.Query(ctx, db, "SELECT * from PERSON WHERE name=:name: and age in (:ages:) and id = :id:", map[string]interface{}{"id": 1, "ages": []int{20, 32}, "name": "Fred"}, &people)
 	if err != nil {
 		t.Fatalf("get by age failed: %v", err)
 	}
 	fmt.Println(people)
 
-	err = b.Query(ctx, db, "SELECT * from PERSON WHERE name=:$1: and age in (:$2:) and id = :$3:", []interface{}{"Fred", []int{20, 32}, 1}, nil, &people)
+	err = b.Query(ctx, db, "SELECT * from PERSON WHERE name=:$1: and age in (:$2:) and id = :$3:", map[string]interface{}{"$1": "Fred", "$2": []int{20, 32}, "$3": 1}, &people)
 	if err != nil {
 		t.Fatalf("get by age 2 failed: %v", err)
 	}
 	fmt.Println(people)
+
+	// or really non-typed
+	var p2 map[string]interface{}
+	err = b.Query(ctx, db, "SELECT * FROM PERSON WHERE id = :id:", map[string]interface{}{"id": 1}, &p2)
+	if err != nil {
+		t.Fatalf("get map failed: %v", err)
+	}
+	fmt.Println(p2)
+
+	var people2 []map[string]interface{}
+	err = b.Query(ctx, db, "SELECT * FROM PERSON where age > :$1: and age < :$2:", map[string]interface{}{"$1": 20, "$2": 50}, &people2)
+	if err != nil {
+		t.Fatalf("get map slice failed: %v", err)
+	}
+	fmt.Println(people2)
+
+	var p3 map[string]interface{}
+	err = b.Query(ctx, db, "SELECT * FROM PERSON WHERE id = :p.Id:", map[string]interface{}{"p": p}, &p3)
+	if err != nil {
+		t.Fatalf("get map 2 failed: %v", err)
+	}
+	fmt.Println(p3)
+
+	var p4 map[string]interface{}
+	err = b.Query(ctx, db, "SELECT * FROM PERSON WHERE id = :p.id:", map[string]interface{}{"p": p3}, &p4)
+	if err != nil {
+		t.Fatalf("get map 2 failed: %v", err)
+	}
+	fmt.Println(p4)
 }
 
 //func doPersonStuffForProteusTest(b *testing.B, wrapper Wrapper) (int64, *Person, []Person, error) {

--- a/proteus_function_test.go
+++ b/proteus_function_test.go
@@ -1,0 +1,122 @@
+package proteus
+
+import (
+	"context"
+	"fmt"
+	"testing"
+)
+
+func TestBuilder_BuildFunction(t *testing.T) {
+	b := NewBuilder(Postgres, nil)
+	db := setupDbPostgres()
+	defer db.Close()
+	ctx := context.Background()
+
+	var f func(c context.Context, e ContextExecutor, name string, age int) (int64, error)
+	err := b.BuildFunction(ctx, &f, "INSERT INTO PERSON(name, age) VALUES(:name:, :age:)", []string{"name", "age"})
+	if err != nil {
+		t.Fatalf("build function failed: %v", err)
+	}
+
+	var g func(c context.Context, q ContextQuerier, id int) (*Person, error)
+	err = b.BuildFunction(ctx, &g, "SELECT * FROM PERSON WHERE id = :id:", []string{"id"})
+	if err != nil {
+		t.Fatalf("build function 2 failed: %v", err)
+	}
+
+	rows, err := f(ctx, db, "Fred", 20)
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	fmt.Println(rows)
+
+	p, err := g(ctx, db, 1)
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	fmt.Println(p)
+}
+
+func TestBuilder_ExecuteQuery(t *testing.T) {
+	b := NewBuilder(Postgres, nil)
+	db := setupDbPostgres()
+	defer db.Close()
+	ctx := context.Background()
+	rows, err := b.Execute(ctx, db, "INSERT INTO PERSON(name, age) VALUES(:name:, :age:)", []interface{}{"Fred", 20}, []string{"name", "age"})
+	if err != nil {
+		t.Fatalf("create failed: %v", err)
+	}
+	fmt.Println(rows)
+	rows, err = b.Execute(ctx, db, "INSERT INTO PERSON(name, age) VALUES(:name:, :age:)", []interface{}{"Bob", 50}, []string{"name", "age"})
+	if err != nil {
+		t.Fatalf("create 2 failed: %v", err)
+	}
+	fmt.Println(rows)
+	rows, err = b.Execute(ctx, db, "INSERT INTO PERSON(name, age) VALUES(:name:, :age:)", []interface{}{"Julia", 32}, []string{"name", "age"})
+	if err != nil {
+		t.Fatalf("create 3 failed: %v", err)
+	}
+	fmt.Println(rows)
+	rows, err = b.Execute(ctx, db, "INSERT INTO PERSON(name, age) VALUES(:name:, :age:)", []interface{}{"Pat", 37}, []string{"name", "age"})
+	if err != nil {
+		t.Fatalf("create 4 failed: %v", err)
+	}
+	fmt.Println(rows)
+
+	var p Person
+	err = b.Query(ctx, db, "SELECT * FROM PERSON WHERE id = :id:", []interface{}{1}, []string{"id"}, &p)
+	if err != nil {
+		t.Fatalf("get failed: %v", err)
+	}
+	fmt.Println(p)
+
+	var people []Person
+	err = b.Query(ctx, db, "SELECT * FROM PERSON", nil, nil, &people)
+	if err != nil {
+		t.Fatalf("get all failed: %v", err)
+	}
+	fmt.Println(people)
+
+	err = b.Query(ctx, db, "SELECT * from PERSON WHERE name=:name: and age in (:ages:) and id = :id:", []interface{}{1, []int{20, 32}, "Fred"}, []string{"id", "ages", "name"}, &people)
+	if err != nil {
+		t.Fatalf("get by age failed: %v", err)
+	}
+	fmt.Println(people)
+
+	err = b.Query(ctx, db, "SELECT * from PERSON WHERE name=:$1: and age in (:$2:) and id = :$3:", []interface{}{"Fred", []int{20, 32}, 1}, nil, &people)
+	if err != nil {
+		t.Fatalf("get by age 2 failed: %v", err)
+	}
+	fmt.Println(people)
+}
+
+//func doPersonStuffForProteusTest(b *testing.B, wrapper Wrapper) (int64, *Person, []Person, error) {
+//
+//	count, err = personDao.Update(wrapper, 1, "Freddie", 30)
+//	if err != nil {
+//		b.Fatalf("update failed: %v", err)
+//	}
+//
+//	person, err = personDao.Get(wrapper, 1)
+//	if err != nil {
+//		b.Fatalf("get 2 failed: %v", err)
+//	}
+//
+//	count, err = personDao.Delete(wrapper, 1)
+//	if err != nil {
+//		b.Fatalf("delete failed: %v", err)
+//	}
+//
+//	count, err = personDao.Delete(wrapper, 1)
+//	if err != nil {
+//		b.Fatalf("delete 2 failed: %v", err)
+//	}
+//
+//	person, err = personDao.Get(wrapper, 1)
+//	if err != nil {
+//		b.Fatalf("get 3 failed: %v", err)
+//	}
+//
+//	return count, person, people, err
+//}
+//

--- a/runner.go
+++ b/runner.go
@@ -289,6 +289,9 @@ func handleMapping(c context.Context, sType reflect.Type, rows *sql.Rows, builde
 		var result interface{}
 		for {
 			result, err = mapRows(c, rows, builder)
+			if err != nil {
+				return nil, err
+			}
 			if result == nil {
 				break
 			}


### PR DESCRIPTION
Also fixed up some error messages so they meet the Go standard (error messages should start with lowercase letters).

The new code has 99% code coverage using a postgres database in a docker container. The goal is to move all testing over to this, plus SQLMock, allowing the removal of SQLite from the project. (The SQLite adapter will remain, but tests and sample code that use SQLite will move to their own project).
