### PR TITLE
FEATURE | use sql.Result as valid output parameter

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,20 +1,24 @@
 
 test:
 	docker-compose up -d db
+	docker-compose up -d mysql
 	go test -v -cover ./...
 
 bench:
 	docker-compose up -d db
+	docker-compose up -d mysql
 	go test -bench=.
 .PHONY:bench
 
 sample:
 	docker-compose up -d db
+	docker-compose up -d mysql
 	go run cmd/sample/main.go
 .PHONY:sample
 
 sample_ctx:
 	docker-compose up -d db
+	docker-compose up -d mysql
 	go run cmd/sample/main.go
 .PHONY:sample_ctx
 

--- a/proteus.go
+++ b/proteus.go
@@ -320,8 +320,14 @@ func validateFunction(funcType reflect.Type) (bool, error) {
 		if funcType.Out(0).Kind() == reflect.Chan {
 			return false, stackerr.New("1st output parameter cannot be a channel")
 		}
-		if isExec && funcType.Out(0).Kind() != reflect.Int64 {
-			return false, stackerr.New("the 1st output parameter of an Executor must be int64")
+		if isExec && funcType.Out(0).Kind() != reflect.Int64 &&
+			funcType.Out(0) != sqlResultType {
+			return false, stackerr.New("the 1st output parameter of an Executor must be int64 or sql.Result")
+		}
+
+		//sql.Result only useful with executor.
+		if !isExec && funcType.Out(0) == sqlResultType {
+			return false, stackerr.New("output parameters of type sql.Result must be combined with Executor")
 		}
 	}
 	return hasContext, nil

--- a/runner.go
+++ b/runner.go
@@ -36,9 +36,11 @@ func buildQueryArgs(c context.Context, funcArgs []reflect.Value, paramOrder []pa
 }
 
 var (
-	errType = reflect.TypeOf((*error)(nil)).Elem()
-	errZero = reflect.Zero(errType)
-	zero    = reflect.ValueOf(int64(0))
+	errType       = reflect.TypeOf((*error)(nil)).Elem()
+	errZero       = reflect.Zero(errType)
+	zeroInt64     = reflect.ValueOf(int64(0))
+	zeroSQLResult = reflect.ValueOf((sql.Result)(nil))
+	sqlResultType = reflect.TypeOf((*sql.Result)(nil)).Elem()
 )
 
 func makeContextExecutorImplementation(c context.Context, funcType reflect.Type, query queryHolder, paramOrder []paramInfo) func(args []reflect.Value) []reflect.Value {
@@ -120,11 +122,14 @@ func makeExecutorReturnVals(funcType reflect.Type) func(sql.Result, error) []ref
 	if numOut == 1 {
 		return func(result sql.Result, err error) []reflect.Value {
 			if err != nil {
-				return []reflect.Value{zero}
+				return []reflect.Value{zeroInt64}
+			}
+			if sType == sqlResultType {
+				return []reflect.Value{reflect.ValueOf(result)}
 			}
 			val, err := result.RowsAffected()
 			if err != nil {
-				return []reflect.Value{zero}
+				return []reflect.Value{zeroInt64}
 			}
 			return []reflect.Value{reflect.ValueOf(val).Convert(sType)}
 		}
@@ -132,12 +137,18 @@ func makeExecutorReturnVals(funcType reflect.Type) func(sql.Result, error) []ref
 	if numOut == 2 {
 		return func(result sql.Result, err error) []reflect.Value {
 			eType := funcType.Out(1)
+			if sType == sqlResultType {
+				if err != nil {
+					return []reflect.Value{zeroSQLResult, reflect.ValueOf(err).Convert(eType)}
+				}
+				return []reflect.Value{reflect.ValueOf(result), errZero}
+			}
 			if err != nil {
-				return []reflect.Value{zero, reflect.ValueOf(err).Convert(eType)}
+				return []reflect.Value{zeroInt64, reflect.ValueOf(err).Convert(eType)}
 			}
 			val, err := result.RowsAffected()
 			if err != nil {
-				return []reflect.Value{zero, reflect.ValueOf(err).Convert(eType)}
+				return []reflect.Value{zeroInt64, reflect.ValueOf(err).Convert(eType)}
 			}
 			return []reflect.Value{reflect.ValueOf(val).Convert(sType), errZero}
 		}
@@ -145,7 +156,7 @@ func makeExecutorReturnVals(funcType reflect.Type) func(sql.Result, error) []ref
 
 	// impossible case since validation should happen first, but be safe
 	return func(result sql.Result, err error) []reflect.Value {
-		return []reflect.Value{zero, reflect.ValueOf(stackerr.New("should never get here"))}
+		return []reflect.Value{zeroInt64, reflect.ValueOf(stackerr.New("should never get here"))}
 	}
 }
 

--- a/runner.go
+++ b/runner.go
@@ -122,6 +122,9 @@ func makeExecutorReturnVals(funcType reflect.Type) func(sql.Result, error) []ref
 	if numOut == 1 {
 		return func(result sql.Result, err error) []reflect.Value {
 			if err != nil {
+				if sType == sqlResultType {
+					return []reflect.Value{zeroSQLResult}
+				}
 				return []reflect.Value{zeroInt64}
 			}
 			if sType == sqlResultType {
@@ -156,7 +159,11 @@ func makeExecutorReturnVals(funcType reflect.Type) func(sql.Result, error) []ref
 
 	// impossible case since validation should happen first, but be safe
 	return func(result sql.Result, err error) []reflect.Value {
-		return []reflect.Value{zeroInt64, reflect.ValueOf(stackerr.New("should never get here"))}
+		impossibleErr := reflect.ValueOf(stackerr.New("should never get here"))
+		if sType == sqlResultType {
+			return []reflect.Value{zeroSQLResult, impossibleErr}
+		}
+		return []reflect.Value{zeroInt64, impossibleErr}
 	}
 }
 


### PR DESCRIPTION
This change enables the user to return an `sql.Result` in the first output parameter, provided they combine it with an Executor or ContextExecutor.

Tests included. ~I have not (yet) attempted to use it in my project.~ (EDIT: see comments)

@jonbodner let me know what you think. I can take a crack at updating the documentation once you approve the change.

Closes #52 