### PR TITLE
Configure proteus to panic on database errors

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,6 +216,32 @@ func init() {
 	}
 }
 ```
+### Database error behavior configuration
+
+Having every DAO function returning an error can make things very cumbersone and repetitive quickly. Sometimes you just want to return a single value without having to check for errors because you are sure that any errors would be fatal, unrecoverable and require human intervention.
+
+```go
+type UserRepository struct {
+	Fetch () func (ctx context.Context, q ContextQuerier)[]*models.Users `proq:"select * from users"`
+}
+```
+The above struct works fine, but if the database throws an error, you won't be able to know. The following configurations will control the behavior of such scenarios.
+
+By passing the following values in the `context.Context` to the `ShouldBuild` function.
+
+```go
+c := context.WithValue(context.Background(), ContextKeyErrorBehavior, PanicAlways)
+ShouldBuild(c, &dao, Postgres)
+```
+
+**`ErrorBehavior` Values**:
+
+
+- `DoNothing` - proteus does not do anything when the underlying data source throws an error.
+- `PanicWhenAbsent` - proteus will `panic`, if the DAO function being called does not have the `error` return type.
+- `PanicAlways` - proteus will always `panic` if there is an error from the data source, whether or not the DAO function being called indicates an `error` return type.
+
+
 
 ## Struct Tags
 

--- a/proteus.go
+++ b/proteus.go
@@ -52,6 +52,12 @@ If the entity is a primitive, then the first value returned for a row must be of
 
 */
 
+type ContextKey string
+
+const (
+	ContextKeyErrorBehavior ContextKey = ContextKey("errorBehavior")
+)
+
 type Error struct {
 	FuncName      string
 	FieldOrder    int
@@ -352,7 +358,7 @@ func makeImplementation(c context.Context, funcType reflect.Type, query string, 
 	case fType.Implements(qType):
 		return makeQuerierImplementation(c, funcType, fixedQuery, paramOrder)
 	}
-	//this should impossible, since we already validated that the first parameter is either an executor or a querier
+	//this should be impossible, since we already validated that the first parameter is either an executor or a querier
 	return nil, stackerr.New("first parameter must be of type Executor or Querier")
 }
 

--- a/proteus_function.go
+++ b/proteus_function.go
@@ -12,9 +12,23 @@ import (
 	"github.com/jonbodner/stackerr"
 )
 
+type ErrorBehavior string
+
+const (
+	// (Default) proteus will do nothing the the query executor returns an error
+	DoNothing ErrorBehavior = "do_nothing"
+
+	// proteus will always panic when the query executor returns an error
+	PanicAlways ErrorBehavior = "panic_always"
+
+	// proteus will panic only if the calling function does not specify error in one of its return types
+	PanicWhenAbsent ErrorBehavior = "panic_if_absent"
+)
+
 type Builder struct {
-	adapter ParamAdapter
-	mappers []QueryMapper
+	adapter       ParamAdapter
+	mappers       []QueryMapper
+	errorBehavior ErrorBehavior
 }
 
 func NewBuilder(adapter ParamAdapter, mappers ...QueryMapper) Builder {


### PR DESCRIPTION
This PR adds the ability to configure proteus to panic (or not) when the underlying database returns an error.

This is especially useful since we have the ability to chose whether a DAO function returns an error or not. In such a case where the error return type is omitted, there would be no way of knowing if the database returned an error. At the same time, reducing the amount of boilerplate code to check for errors that may actually never exist.

Configuration is done by passing three values in the build context.

- Introduced a new type `ContextKey` as key type for passing values in the builder context 
- Introduced a new type `ErrorBehavior` to control the said scenarios.

**`ErrorBehavior` Values**:

- `DoNothing` (Default) - proteus does not do anything when the underlying data source throws an error.
- `PanicWhenAbsent` - proteus will `panic`, only if the DAO function being called does not have the `error` return type.
- `PanicAlways` - proteus will always `panic` if there is an error from the data source, whether or not the DAO function being called indicates an `error` return type.
