### PR TITLE
Bump GitHub workflow actions to latest versions

### DIFF
--- a/.github/workflows/staticcheck.yml
+++ b/.github/workflows/staticcheck.yml
@@ -17,12 +17,12 @@ jobs:
 
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
 
       - name: Setup Go
-        uses: actions/setup-go@v2
+        uses: actions/setup-go@v5
         with:
-          go-version: 1.19
+          go-version: 1.22
 
       - name: Install staticcheck
         run: make install
@@ -32,7 +32,7 @@ jobs:
 
       - name: Save results
         if: always()
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: staticcheck-results
           path: staticcheck-result.txt


### PR DESCRIPTION
This PR bumps GitHub workflow actions to their latest versions, thus avoiding deprecation messages as seen e.g. [here](https://github.com/jonbodner/proteus/actions/runs/6937662742).